### PR TITLE
Implement order webhook

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,13 +1,17 @@
 import express from 'express';
 import dotenv from 'dotenv';
 import shopifyAuth from './shopify/auth';
+import orderSync from './shopify/orderSync';
 
 dotenv.config();
 
 const app = express();
 const port = process.env.PORT || 3000;
 
+app.use(express.json());
+
 app.use('/shopify', shopifyAuth);
+app.use('/shopify', orderSync);
 
 app.get('/', (req, res) => {
   res.send('RocketPress API');

--- a/src/shopify/orderSync.test.ts
+++ b/src/shopify/orderSync.test.ts
@@ -1,0 +1,25 @@
+import request from 'supertest';
+import express from 'express';
+import router, { getUnfulfilledOrders, clearOrders } from './orderSync';
+
+describe('orderSync webhook', () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/shopify', router);
+
+  beforeEach(() => {
+    clearOrders();
+  });
+
+  test('captures unfulfilled orders', async () => {
+    const order = { id: 1, fulfillment_status: null };
+    await request(app).post('/shopify/webhook/orders/create').send(order).expect(200);
+    expect(getUnfulfilledOrders()).toHaveLength(1);
+  });
+
+  test('ignores fulfilled orders', async () => {
+    const order = { id: 2, fulfillment_status: 'fulfilled' };
+    await request(app).post('/shopify/webhook/orders/create').send(order).expect(200);
+    expect(getUnfulfilledOrders()).toHaveLength(0);
+  });
+});

--- a/src/shopify/orderSync.ts
+++ b/src/shopify/orderSync.ts
@@ -1,0 +1,34 @@
+import { Router, RequestHandler, Request, Response } from 'express';
+
+export interface ShopifyOrder {
+  id: number;
+  fulfillment_status: string | null;
+  [key: string]: any;
+}
+
+const router = Router();
+const unfulfilledOrders: ShopifyOrder[] = [];
+
+const handleOrder: RequestHandler = (req: Request, res: Response) => {
+  const order: ShopifyOrder = req.body as ShopifyOrder;
+  if (!order) {
+    res.status(400).send('Invalid order');
+    return;
+  }
+  if (!order.fulfillment_status || order.fulfillment_status === 'unfulfilled') {
+    unfulfilledOrders.push(order);
+  }
+  res.status(200).send('OK');
+};
+
+router.post('/webhook/orders/create', handleOrder);
+
+export function getUnfulfilledOrders() {
+  return unfulfilledOrders;
+}
+
+export function clearOrders() {
+  unfulfilledOrders.length = 0;
+}
+
+export default router;

--- a/tasks/tasks-PRD.md
+++ b/tasks/tasks-PRD.md
@@ -28,7 +28,7 @@
 ## Tasks
 - [ ] 1.0 Shopify Integration & Order Sync
   - [x] 1.1 Set up Node.js Shopify app with OAuth and initial project structure.
-  - [ ] 1.2 Implement order webhook to capture unfulfilled orders.
+  - [x] 1.2 Implement order webhook to capture unfulfilled orders.
   - [ ] 1.3 Map SKUs to artwork files and blank garment SKUs.
   - [ ] 1.4 Persist order data and fulfillment status in the database.
   - [ ] 1.5 Write unit tests for order sync logic.


### PR DESCRIPTION
## Summary
- add JSON parsing middleware and order sync router in app
- implement `/webhook/orders/create` webhook
- test order webhook handling
- mark task 1.2 complete in PRD tasks

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6847ac144b988328a4c1b72f086f6efd