### PR TITLE
Implement multi-store order webhook (task 1.3)

### DIFF
--- a/tasks/tasks-PRD.md
+++ b/tasks/tasks-PRD.md
@@ -34,7 +34,7 @@
 - [ ] 1.0 Shopify Integration & Multi-Store Order Sync
   - [x] 1.1 Set up Node.js Shopify app with OAuth and initial project structure.
   - [x] 1.2 Add multi-store authentication with per-shop tokens stored in PostgreSQL.
-  - [ ] 1.3 Implement order webhook to capture unfulfilled orders for each store.
+  - [x] 1.3 Implement order webhook to capture unfulfilled orders for each store.
   - [ ] 1.4 Map SKUs to artwork files and blank garment SKUs.
   - [ ] 1.5 Persist order data and fulfillment status with a shop reference.
   - [ ] 1.6 Write unit tests for multi-store order sync logic.


### PR DESCRIPTION
## Summary
- capture shop domain from webhook requests
- store unfulfilled orders per shop in memory
- expose helper to retrieve orders for a specific shop
- update tests for multi-store webhook handling
- mark task 1.3 complete

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849c403619483289c2833cccd7198b9