### PR TITLE
Implement per-shop SKU mapping

### DIFF
--- a/src/shopify/orderSync.test.ts
+++ b/src/shopify/orderSync.test.ts
@@ -16,7 +16,10 @@ describe('orderSync webhook', () => {
   beforeEach(async () => {
     await clearOrders();
     clearSkuMappings();
-    addSkuMapping('SKU1', { artworkFile: 'designs/sku1.png', blankSku: 'BLANK1' });
+    addSkuMapping('shop1.myshopify.com', 'SKU1', {
+      artworkFile: 'designs/sku1.png',
+      blankSku: 'BLANK1',
+    });
   });
 
   test('captures unfulfilled orders', async () => {

--- a/src/shopify/orderSync.ts
+++ b/src/shopify/orderSync.ts
@@ -29,7 +29,7 @@ const handleOrder: RequestHandler = async (req: Request, res: Response) => {
   }
   const mappedLineItems: MappedLineItem[] =
     (order.line_items || []).map((item: any) => {
-      const mapping = getSkuMapping(item.sku) || {
+      const mapping = getSkuMapping(shop, item.sku) || {
         artworkFile: '',
         blankSku: '',
       };

--- a/src/shopify/skuMapper.test.ts
+++ b/src/shopify/skuMapper.test.ts
@@ -1,18 +1,42 @@
 import { getSkuMapping, addSkuMapping, clearSkuMappings } from './skuMapper';
 
 describe('skuMapper', () => {
+  const shop = 'shop1.myshopify.com';
+
   beforeEach(() => {
     clearSkuMappings();
-    addSkuMapping('SKU1', { artworkFile: 'designs/sku1.png', blankSku: 'BLANK1' });
+    addSkuMapping(shop, 'SKU1', {
+      artworkFile: 'designs/sku1.png',
+      blankSku: 'BLANK1',
+    });
   });
 
   test('returns mapping for known SKU', () => {
-    const mapping = getSkuMapping('SKU1');
-    expect(mapping).toEqual({ artworkFile: 'designs/sku1.png', blankSku: 'BLANK1' });
+    const mapping = getSkuMapping(shop, 'SKU1');
+    expect(mapping).toEqual({
+      artworkFile: 'designs/sku1.png',
+      blankSku: 'BLANK1',
+    });
   });
 
   test('returns undefined for unknown SKU', () => {
-    const mapping = getSkuMapping('UNKNOWN');
+    const mapping = getSkuMapping(shop, 'UNKNOWN');
     expect(mapping).toBeUndefined();
+  });
+
+  test('maintains separate mappings per shop', () => {
+    addSkuMapping('shop2.myshopify.com', 'SKU1', {
+      artworkFile: 'designs/sku1_alt.png',
+      blankSku: 'BLANK2',
+    });
+
+    expect(getSkuMapping(shop, 'SKU1')).toEqual({
+      artworkFile: 'designs/sku1.png',
+      blankSku: 'BLANK1',
+    });
+    expect(getSkuMapping('shop2.myshopify.com', 'SKU1')).toEqual({
+      artworkFile: 'designs/sku1_alt.png',
+      blankSku: 'BLANK2',
+    });
   });
 });

--- a/src/shopify/skuMapper.ts
+++ b/src/shopify/skuMapper.ts
@@ -3,22 +3,34 @@ export interface SkuMapping {
   blankSku: string;
 }
 
-const mappings: Record<string, SkuMapping> = {
-  SKU1: { artworkFile: 'designs/sku1.png', blankSku: 'BLANK1' },
-  SKU2: { artworkFile: 'designs/sku2.png', blankSku: 'BLANK2' },
-};
+// mappings are stored per shop to support multi-store setups
+const mappings: Record<string, Record<string, SkuMapping>> = {};
 
-export function getSkuMapping(sku: string): SkuMapping | undefined {
-  return mappings[sku];
+export function getSkuMapping(
+  shop: string,
+  sku: string
+): SkuMapping | undefined {
+  return mappings[shop]?.[sku];
 }
 
-export function addSkuMapping(sku: string, mapping: SkuMapping) {
-  mappings[sku] = mapping;
+export function addSkuMapping(
+  shop: string,
+  sku: string,
+  mapping: SkuMapping
+) {
+  if (!mappings[shop]) {
+    mappings[shop] = {};
+  }
+  mappings[shop][sku] = mapping;
 }
 
-export function clearSkuMappings() {
-  for (const key of Object.keys(mappings)) {
-    delete mappings[key];
+export function clearSkuMappings(shop?: string) {
+  if (shop) {
+    delete mappings[shop];
+  } else {
+    for (const key of Object.keys(mappings)) {
+      delete mappings[key];
+    }
   }
 }
 

--- a/tasks/tasks-PRD.md
+++ b/tasks/tasks-PRD.md
@@ -35,7 +35,7 @@
   - [x] 1.1 Set up Node.js Shopify app with OAuth and initial project structure.
   - [x] 1.2 Add multi-store authentication with per-shop tokens stored in PostgreSQL.
   - [x] 1.3 Implement order webhook to capture unfulfilled orders for each store.
-  - [ ] 1.4 Map SKUs to artwork files and blank garment SKUs.
+  - [x] 1.4 Map SKUs to artwork files and blank garment SKUs.
   - [ ] 1.5 Persist order data and fulfillment status with a shop reference.
   - [ ] 1.6 Write unit tests for multi-store order sync logic.
 - [ ] 2.0 Artwork Management with AI Gang Sheet Generation


### PR DESCRIPTION
## Summary
- map SKUs per shop domain
- adjust order sync to use per-shop mappings
- test skuMapper with per-shop mappings
- update order sync tests
- mark task 1.4 complete in PRD

## Testing
- `npm install`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6849e023140c83288888f2f628811af9