### PR TITLE
Implement task 1.5

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -13,17 +13,18 @@ if (process.env.NODE_ENV === 'test') {
 
 export async function initDb() {
   await pool.query(`
-    CREATE TABLE IF NOT EXISTS orders (
-      id BIGINT PRIMARY KEY,
-      data JSONB NOT NULL,
-      fulfillment_status TEXT
+    CREATE TABLE IF NOT EXISTS shops (
+      shop TEXT PRIMARY KEY,
+      access_token TEXT NOT NULL
     )
   `);
 
   await pool.query(`
-    CREATE TABLE IF NOT EXISTS shops (
-      shop TEXT PRIMARY KEY,
-      access_token TEXT NOT NULL
+    CREATE TABLE IF NOT EXISTS orders (
+      id BIGINT PRIMARY KEY,
+      shop TEXT NOT NULL,
+      data JSONB NOT NULL,
+      fulfillment_status TEXT
     )
   `);
 }

--- a/src/shopify/orderSync.test.ts
+++ b/src/shopify/orderSync.test.ts
@@ -69,11 +69,14 @@ describe('orderSync webhook', () => {
       .set('X-Shopify-Shop-Domain', 'shop1.myshopify.com')
       .send(order)
       .expect(200);
-    const result = await pool.query('SELECT * FROM orders WHERE id = $1', [
-      order.id,
-    ]);
+    const result = await pool.query(
+      'SELECT * FROM orders WHERE id = $1 AND shop = $2',
+      [order.id, 'shop1.myshopify.com']
+    );
     expect(result.rows).toHaveLength(1);
     expect(result.rows[0].id).toBe(order.id);
+    expect(result.rows[0].shop).toBe('shop1.myshopify.com');
+    expect(result.rows[0].fulfillment_status).toBeNull();
   });
 
   test('tracks unfulfilled orders separately for each shop', async () => {

--- a/tasks/tasks-PRD.md
+++ b/tasks/tasks-PRD.md
@@ -36,7 +36,7 @@
   - [x] 1.2 Add multi-store authentication with per-shop tokens stored in PostgreSQL.
   - [x] 1.3 Implement order webhook to capture unfulfilled orders for each store.
   - [x] 1.4 Map SKUs to artwork files and blank garment SKUs.
-  - [ ] 1.5 Persist order data and fulfillment status with a shop reference.
+  - [x] 1.5 Persist order data and fulfillment status with a shop reference.
   - [ ] 1.6 Write unit tests for multi-store order sync logic.
 - [ ] 2.0 Artwork Management with AI Gang Sheet Generation
   - [ ] 2.1 Build service to associate SKUs with artwork files.


### PR DESCRIPTION
## Summary
- persist orders with a `shop` reference
- update order sync to store the shop in DB
- verify shop persistence in tests
- mark task 1.5 complete

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849e31cf2e0832898cbfc2b868d2d52