### PR TITLE
Fix Render build by auto-compiling TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # RocketPress
 fully automate the order, print, press, and ship workflow for direct-to-film (DTF) print shops, particularly those using Shopify. AutoDTF integrates with Shopify and suppliers like S&amp;S Activewear to create an efficient, minimal-touch system that reduces human error and boosts throughput.
+
+## Development
+
+Install dependencies and run the tests:
+
+```bash
+npm install
+npm test
+```
+
+## Building
+
+Compile the TypeScript source to the `dist` directory:
+
+```bash
+npm run build
+```
+
+## Deployment
+
+The project defines a `prepare` script so `npm install` automatically compiles the TypeScript. Platforms such as Render that only run `npm install` during the build step will therefore generate the `dist` files automatically. Start the service with:
+
+```bash
+node dist/index.js
+```
+
+See `.env.example` for the required environment variables.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts",
-    "test": "jest"
+    "test": "jest",
+    "prepare": "npm run build"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- ensure Render compiles TypeScript by running `tsc` in the `prepare` script
- document build and deployment steps in the README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a0094d298832887ffedbdf9fca6f6